### PR TITLE
Read-only deploy key instead of PAT

### DIFF
--- a/.github/actions/prepare-ios-build-environment/action.yml
+++ b/.github/actions/prepare-ios-build-environment/action.yml
@@ -41,6 +41,8 @@ runs:
     - name: Generate Git private key for Match
       env:
         MATCH_GIT_PRIVATE_KEY: ${{ inputs.match-git-private-key-content }}
-      run: echo "$MATCH_GIT_PRIVATE_KEY" > match-git-key.pem
+      run: |
+        echo "$MATCH_GIT_PRIVATE_KEY" > match-git-key.pem
+        chmod 400 match-git-key.pem
       working-directory: ios
       shell: bash

--- a/.github/actions/prepare-ios-build-environment/action.yml
+++ b/.github/actions/prepare-ios-build-environment/action.yml
@@ -1,6 +1,11 @@
 name: Prepare iOS build environment
 description: Prepare application's build environment
 
+inputs:
+  match-git-private-key-content:
+    description: 'Required input to set Match git private key content'
+    required: true
+
 runs:
   using: composite
   steps:
@@ -30,5 +35,12 @@ runs:
 
     - name: Install iOS pods
       run: pod install
+      working-directory: ios
+      shell: bash
+
+    - name: Generate Git private key for Match
+      env:
+        MATCH_GIT_PRIVATE_KEY: ${{ inputs.match-git-private-key-content }}
+      run: echo "$MATCH_GIT_PRIVATE_KEY" > match-git-key.pem
       working-directory: ios
       shell: bash

--- a/.github/actions/prepare-ios-build-environment/action.yml
+++ b/.github/actions/prepare-ios-build-environment/action.yml
@@ -6,6 +6,11 @@ inputs:
     description: 'Required input to set Match git private key content'
     required: true
 
+outputs:
+  match-git-private-key-path:
+    description: 'Match GIT private key path'
+    value: ${{ steps.match-git-key.outputs.match-git-private-key-path }}
+
 runs:
   using: composite
   steps:
@@ -39,10 +44,12 @@ runs:
       shell: bash
 
     - name: Generate Git private key for Match
+      id: match-git-key
       env:
         MATCH_GIT_PRIVATE_KEY: ${{ inputs.match-git-private-key-content }}
       run: |
         echo "$MATCH_GIT_PRIVATE_KEY" > match-git-key.pem
         chmod 400 match-git-key.pem
+        echo "match-git-private-key-path=$(realpath match-git-key.pem)" >> "${GITHUB_OUTPUT}"
       working-directory: ios
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           FASTLANE_TEAM_ID: ${{ secrets.FASTLANE_TEAM_ID }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
-          MATCH_GIT_PRIVATE_KEY: ${{ needs.ios-build-environment.outputs.match-git-private-key-path }}
+          MATCH_GIT_PRIVATE_KEY: ${{ steps.ios-build-environment.outputs.match-git-private-key-path }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
 
   actionlint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Prepare build environment
         uses: ./.github/actions/prepare-ios-build-environment
+        id: ios-build-environment
         with:
           match-git-private-key-content: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
 
@@ -56,7 +57,7 @@ jobs:
         env:
           FASTLANE_TEAM_ID: ${{ secrets.FASTLANE_TEAM_ID }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
-          MATCH_GIT_PRIVATE_KEY: 'match-git-key.pem'
+          MATCH_GIT_PRIVATE_KEY: ${{ needs.ios-build-environment.outputs.match-git-private-key-path }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
 
   actionlint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Prepare build environment
         uses: ./.github/actions/prepare-ios-build-environment
+        with:
+          match-git-private-key-content: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
 
       - name: Build iOS
         run: bundle exec fastlane ios ci
@@ -54,7 +56,7 @@ jobs:
         env:
           FASTLANE_TEAM_ID: ${{ secrets.FASTLANE_TEAM_ID }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
-          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          MATCH_GIT_PRIVATE_KEY: 'match-git-key.pem'
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
 
   actionlint:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,6 +175,8 @@ jobs:
 
       - name: Prepare build environment
         uses: ./.github/actions/prepare-ios-build-environment
+        with:
+          match-git-private-key-content: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
 
       - name: Fastlane publish to TestFlight
         run: bundle exec fastlane ios publish_testflight
@@ -185,7 +187,7 @@ jobs:
           APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
-          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          MATCH_GIT_PRIVATE_KEY: 'match-git-key.pem'
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
 
           VERSION_NAME: ${{ needs.config.outputs.version-name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,6 +175,7 @@ jobs:
 
       - name: Prepare build environment
         uses: ./.github/actions/prepare-ios-build-environment
+        id: ios-build-environment
         with:
           match-git-private-key-content: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
 
@@ -187,7 +188,7 @@ jobs:
           APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
-          MATCH_GIT_PRIVATE_KEY: 'match-git-key.pem'
+          MATCH_GIT_PRIVATE_KEY: ${{ needs.ios-build-environment.outputs.match-git-private-key-path }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
 
           VERSION_NAME: ${{ needs.config.outputs.version-name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -188,7 +188,7 @@ jobs:
           APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
-          MATCH_GIT_PRIVATE_KEY: ${{ needs.ios-build-environment.outputs.match-git-private-key-path }}
+          MATCH_GIT_PRIVATE_KEY: ${{ steps.ios-build-environment.outputs.match-git-private-key-path }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
 
           VERSION_NAME: ${{ needs.config.outputs.version-name }}


### PR DESCRIPTION
Replace personal access token with read-only deploy key for iOS certificates. 